### PR TITLE
fix: 사이드바의 소셜 아이콘 중 하나만 갖다대도 전부 반응하는 이슈 해결

### DIFF
--- a/_includes/default-social-list.html
+++ b/_includes/default-social-list.html
@@ -1,23 +1,23 @@
 {% if site.social.github %}
-<a href="{{ site.social.github }}" class="social-icon text-inherit"><i class="bi bi-github" alt="github"></i></a>
+<a href="{{ site.social.github }}" class="social-icon text-inherit"><i class="bi bi-github social-icon-color" alt="github"></i></a>
 {% endif %}
 
 {% if site.social.email %}
-<a href="{{ 'mailto:' | append: site.social.email }}" class="social-icon text-inherit"><i class="bi bi-envelope-fill" alt="email"></i></a>
+<a href="{{ 'mailto:' | append: site.social.email }}" class="social-icon text-inherit"><i class="bi bi-envelope-fill social-icon-color" alt="email"></i></a>
 {% endif %}
 
 {% if site.social.x %}
-<a href="{{ site.social.x }}" class="social-icon text-inherit"><i class="bi bi-twitter-x" alt="x"></i></a>
+<a href="{{ site.social.x }}" class="social-icon text-inherit"><i class="bi bi-twitter-x social-icon-color" alt="x"></i></a>
 {% endif %}
 
 {% if site.social.instagram %}
-<a href="{{ site.social.instagram }}" class="social-icon text-inherit"><i class="bi bi-instagram"></i></a>
+<a href="{{ site.social.instagram }}" class="social-icon text-inherit"><i class="bi bi-instagram social-icon-color"></i></a>
 {% endif %}
 
 {% if site.social.youtube %}
-<a href="{{ site.social.youtube }}" class="social-icon text-inherit"><i class="bi bi-youtube"></i></a>
+<a href="{{ site.social.youtube }}" class="social-icon text-inherit"><i class="bi bi-youtube social-icon-color"></i></a>
 {% endif %}
 
 {% if site.social.website %}
-<a href="{{ site.social.website }}" class="social-icon text-inherit"><i class="bi bi-globe-asia-australia"></i></a>
+<a href="{{ site.social.website }}" class="social-icon text-inherit"><i class="bi bi-globe-asia-australia social-icon-color"></i></a>
 {% endif %}

--- a/_includes/left-side.html
+++ b/_includes/left-side.html
@@ -12,7 +12,7 @@
         <p>{{ site.user_description }}</p>
     </div>
 
-    <div class="sidebar-social-icon-color w-full mt-10 flex flex-wrap justify-center gap-8">
+    <div class="w-full mt-10 flex flex-wrap justify-center gap-8">
         {% include default-social-list.html %}
     </div>
 

--- a/tailwind/src/default-styles.css
+++ b/tailwind/src/default-styles.css
@@ -102,7 +102,8 @@
 /* Social Icon Style */
 @layer components {
     .social-icon        { @apply text-3xl cursor-pointer decoration-inherit; }
-    .sidebar-social-icon-color  { @apply text-cyan-500 hover:text-cyan-700 dark:text-yellow-200 dark:hover:text-yellow-400; }
+    .social-icon-color  { @apply xl:text-cyan-500 xl:hover:text-cyan-700 dark:xl:text-yellow-200 dark:xl:hover:text-yellow-400
+                                    text-gray-50 hover:text-gray-200; }
 }
 
 @layer components {


### PR DESCRIPTION
* 각 아이콘 태그에 `social-icon-color` 이름의 클래스 추가
* `social-icon-color`는 브라우저 창의 너비에 따라 색상이 달라짐
  * 너비가 넓을 때는 사이드바의 소셜 아이콘이 보여야 하므로 파란색 계열
  * 너비가 좁을 때는 푸터의 아이콘이 보여야 하므로 하얀색 계열